### PR TITLE
Add light color control functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This MCP allows AI assistants to control your Home Assistant devices. It provide
 
 1. Search for entities in your Home Assistant instance
 2. Control devices (turn them on/off)
+3. Control light colors and brightness
 
 ## Prerequisites
 
@@ -80,11 +81,29 @@ Once configured, you can use Cursor AI to control your Home Assistant devices:
 
 - Search for devices: "Find my living room lights"
 - Control devices: "Turn on the kitchen light"
+- Control light colors: "Set my living room lights to red"
+- Adjust brightness: "Set my dining room lights to blue at 50% brightness"
+
+### Light Control Features
+
+The MCP now supports advanced light control capabilities:
+
+1. **Color Control**: Set any RGB color for compatible lights
+   - Specify colors using RGB values (0-255 for each component)
+   - Example: `set_device_color("light.living_room", 255, 0, 0)` for red
+
+2. **Brightness Control**: Adjust light brightness
+   - Optional brightness parameter (0-255)
+   - Can be combined with color changes
+   - Example: `set_device_color("light.dining_room", 0, 0, 255, brightness=128)` for medium-bright blue
 
 ## Troubleshooting
 
 - If you get authentication errors, verify your token is correct and has not expired
 - Check that your Home Assistant instance is reachable at the configured URL
+- For color control issues:
+  - Verify that your light entity supports RGB color control
+  - Check that the light is turned on before attempting to change colors
 
 ## Future Capabilities
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,6 +1,6 @@
 from .config import validate_config
 from .api import make_ha_request, get_all_entities
-from .tools import init_tools, control_device, search_entities
+from .tools import init_tools, control_device, search_entities, set_device_color
 from .utils import search_entities_by_keywords, format_entity_results
 
 __all__ = [
@@ -10,6 +10,7 @@ __all__ = [
     'init_tools',
     'control_device',
     'search_entities',
+    'set_device_color',
     'search_entities_by_keywords',
     'format_entity_results'
 ]

--- a/app/api/home_assistant.py
+++ b/app/api/home_assistant.py
@@ -1,8 +1,8 @@
-from typing import Dict, Any, List
+from typing import Dict, Any, List, Optional
 import httpx
 from ..config import HA_URL, HOME_ASSISTANT_TOKEN, USER_AGENT
 
-async def make_ha_request(domain: str, service: str, entity_id: str) -> Dict[str, Any]:
+async def make_ha_request(domain: str, service: str, entity_id: str, additional_data: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
     """Make a request to the Home Assistant API with proper error handling."""
     url = f"{HA_URL}/api/services/{domain}/{service}"
     
@@ -12,6 +12,8 @@ async def make_ha_request(domain: str, service: str, entity_id: str) -> Dict[str
         "User-Agent": USER_AGENT
     }
     payload = {"entity_id": entity_id}
+    if additional_data:
+        payload.update(additional_data)
     
     async with httpx.AsyncClient() as client:
         try:
@@ -20,6 +22,22 @@ async def make_ha_request(domain: str, service: str, entity_id: str) -> Dict[str
             return {"success": True, "status_code": response.status_code}
         except Exception as e:
             return {"success": False, "error": str(e)}
+
+async def set_light_color(entity_id: str, rgb_color: List[int], brightness: Optional[int] = None) -> Dict[str, Any]:
+    """Set the color and optionally brightness of a light entity.
+    
+    Args:
+        entity_id: The entity ID of the light
+        rgb_color: List of 3 integers [r, g, b] each between 0 and 255
+        brightness: Optional brightness level between 0 and 255
+    """
+    additional_data = {
+        "rgb_color": rgb_color
+    }
+    if brightness is not None:
+        additional_data["brightness"] = brightness
+    
+    return await make_ha_request("light", "turn_on", entity_id, additional_data)
 
 async def get_all_entities() -> List[Dict[str, Any]]:
     """Fetch all entities from Home Assistant."""
@@ -37,4 +55,4 @@ async def get_all_entities() -> List[Dict[str, Any]]:
             response.raise_for_status()
             return response.json()
         except Exception as e:
-            return [] 
+            return []

--- a/app/tools/__init__.py
+++ b/app/tools/__init__.py
@@ -1,3 +1,3 @@
-from .device_controls import init_tools, control_device, search_entities
+from .device_controls import init_tools, control_device, search_entities, set_device_color
 
-__all__ = ['init_tools', 'control_device', 'search_entities']
+__all__ = ['init_tools', 'control_device', 'search_entities', 'set_device_color']

--- a/app/tools/device_controls.py
+++ b/app/tools/device_controls.py
@@ -1,6 +1,6 @@
-from typing import Dict, Any
+from typing import Dict, Any, List
 from mcp.server.fastmcp import FastMCP
-from ..api.home_assistant import make_ha_request, get_all_entities
+from ..api.home_assistant import make_ha_request, get_all_entities, set_light_color
 from ..config import HOME_ASSISTANT_TOKEN
 from ..utils.search import search_entities_by_keywords, format_entity_results
 
@@ -16,6 +16,7 @@ def init_tools(fastmcp_instance: FastMCP):
     # Register tools with the FastMCP instance
     fastmcp_instance.tool()(control_device)
     fastmcp_instance.tool()(search_entities)
+    fastmcp_instance.tool()(set_device_color)  # Register set_device_color like other tools
 
 async def control_device(entity_id: str, state: str) -> str:
     """Control a Home Assistant entity by turning it on or off.
@@ -48,6 +49,43 @@ async def control_device(entity_id: str, state: str) -> str:
     else:
         return f"Failed to control {entity_id}: {result.get('error', 'Unknown error')}"
 
+async def set_device_color(entity_id: str, red: int, green: int, blue: int, brightness: int = None) -> str:
+    """Set the color and optionally brightness of a light entity.
+    
+    Args:
+        entity_id: The Home Assistant entity ID to control (format: light.entity)
+        red: Red component (0-255)
+        green: Green component (0-255)
+        blue: Blue component (0-255)
+        brightness: Optional brightness level (0-255)
+    """
+    # Basic validation
+    if not entity_id or not entity_id.startswith("light."):
+        return f"Invalid entity ID format: {entity_id}. Must be a light entity (format: light.entity)"
+    
+    # Validate RGB values
+    for color, name in [(red, "Red"), (green, "Green"), (blue, "Blue")]:
+        if not 0 <= color <= 255:
+            return f"Invalid {name} value: {color}. Must be between 0 and 255"
+    
+    # Validate brightness if provided
+    if brightness is not None and not 0 <= brightness <= 255:
+        return f"Invalid brightness value: {brightness}. Must be between 0 and 255"
+    
+    # Check token
+    if not HOME_ASSISTANT_TOKEN:
+        return "Home Assistant token not configured. Set HOME_ASSISTANT_TOKEN environment variable."
+    
+    # Call the HA API
+    result = await set_light_color(entity_id, [red, green, blue], brightness)
+    
+    if result["success"]:
+        color_msg = f"color to RGB({red},{green},{blue})"
+        brightness_msg = f" and brightness to {brightness}" if brightness is not None else ""
+        return f"Successfully set {entity_id} {color_msg}{brightness_msg}"
+    else:
+        return f"Failed to set color for {entity_id}: {result.get('error', 'Unknown error')}"
+
 async def search_entities(description: str) -> str:
     """Search for Home Assistant entities matching a natural language description.
     
@@ -68,4 +106,4 @@ async def search_entities(description: str) -> str:
     
     # Search and format results
     matches = search_entities_by_keywords(entities, description)
-    return format_entity_results(matches) 
+    return format_entity_results(matches)


### PR DESCRIPTION
This PR adds support for controlling light colors and brightness in Home Assistant through the MCP server.

### Features Added
- New `set_device_color` tool function to control light colors and brightness
- Support for RGB color values (0-255 for each component)
- Optional brightness control (0-255)
- Input validation for all parameters
- Updated documentation in README.md

### Implementation Details
1. Added `set_light_color` function to Home Assistant API module
2. Added `set_device_color` tool function with proper validation
3. Updated all necessary __init__.py files to expose the new functionality
4. Added comprehensive documentation including usage examples

### Testing
The functionality has been tested with:
- Setting different colors on light entities
- Combining color changes with brightness adjustments
- Input validation for all parameters
- Error handling for invalid inputs

### Example Usage
```python
# Set light to red at full brightness
await set_device_color("light.living_room", 255, 0, 0, brightness=255)

# Set light to blue at 50% brightness
await set_device_color("light.dining_room", 0, 0, 255, brightness=128)

# Change color only without affecting brightness
await set_device_color("light.bedroom", 0, 255, 0)
```

### Documentation
- Added new section in README.md about color control features
- Included usage examples and parameter descriptions
- Updated troubleshooting section with color-specific guidance

### Breaking Changes
None. This is a purely additive change that maintains backward compatibility with existing functionality.