### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A Model Context Protocol (MCP) integration for controlling Home Assistant devices using AI assistants.
 
+<a href="https://glama.ai/mcp/servers/@hpohlmann/home-assistant-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@hpohlmann/home-assistant-mcp/badge" alt="Home Assistant MCP server" />
+</a>
+
 ## Overview
 
 This MCP allows AI assistants to control your Home Assistant devices. It provides tools to:


### PR DESCRIPTION
This PR adds a badge for the [Home Assistant MCP](https://glama.ai/mcp/servers/@hpohlmann/home-assistant-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@hpohlmann/home-assistant-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@hpohlmann/home-assistant-mcp/badge" alt="Home Assistant MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.